### PR TITLE
Create content for Trust and Safety page

### DIFF
--- a/client/src/SmallDisplayCard.tsx
+++ b/client/src/SmallDisplayCard.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import Typography from '@material-ui/core/Typography';
+import { makeStyles } from '@material-ui/core/styles';
+import { Card } from '@material-ui/core';
+
+import type { Theme } from '@material-ui/core/styles';
+
+const useStyles = makeStyles((theme: Theme) => ({
+
+}));
+
+function SmallDisplayCard() {
+    const classes = useStyles();
+
+    return (
+        <Card>
+            Card
+        </Card>
+    );
+}
+
+export default SmallDisplayCard;

--- a/client/src/SmallDisplayCard.tsx
+++ b/client/src/SmallDisplayCard.tsx
@@ -5,13 +5,13 @@ import { Card, Box } from '@material-ui/core';
 
 import type { Theme } from '@material-ui/core/styles';
 
+// Should probably move the width and height out of the component, maybe pass it in
 const circleSize = 76;
 const width = 325;
 const height = 133;
 
 const useStyles = makeStyles((theme: Theme) => ({
     smallDisplayCard: {
-        // Should probably move the sizing out of the component, maybe pass it in
         maxWidth: `${width}px`,
         height: `${height}px`,
         display: 'flex',
@@ -24,6 +24,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     content: {
         height: '100%',
         paddingLeft: '50px',
+        paddingRight: '10px',
         display: 'flex',
         flexDirection: 'column',
         alignItems: 'flex-start',
@@ -37,6 +38,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     cardBody: {
         fontSize: '15px',
         textAlign: 'left',
+        maxHeight: `${height-40}px`,
     },
     circleWrapper: {
         width: '1px',
@@ -57,8 +59,14 @@ const useStyles = makeStyles((theme: Theme) => ({
     },
 }));
 
-function SmallDisplayCard() {
+type Props = {
+    headerText: string,
+    bodyText: string,
+};  
+
+function SmallDisplayCard(props: Props): JSX.Element {
     const classes = useStyles();
+    const { headerText, bodyText } = props;
 
     return (
         <Card className={classes.smallDisplayCard}>
@@ -67,10 +75,10 @@ function SmallDisplayCard() {
             </Box>
             <Box className={classes.content}>
                 <Typography className={classes.cardTitle} variant="body1" component="div">
-                    Card
+                    {headerText}
                 </Typography>
                 <Typography className={classes.cardBody} variant="body1" component="div">
-                    Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+                    {bodyText}
                 </Typography>
             </Box>
         </Card>

--- a/client/src/SmallDisplayCard.tsx
+++ b/client/src/SmallDisplayCard.tsx
@@ -1,20 +1,48 @@
 import * as React from 'react';
 import Typography from '@material-ui/core/Typography';
 import { makeStyles } from '@material-ui/core/styles';
-import { Card } from '@material-ui/core';
+import { Card, Box } from '@material-ui/core';
 
 import type { Theme } from '@material-ui/core/styles';
 
 const useStyles = makeStyles((theme: Theme) => ({
-
+    smallDisplayCard: {
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'flex-start',
+        justifyContent: 'center',
+        width: '325px',
+        height: '133px',
+        backgroundColor: '#767676',
+        color: '#FFFFFF',
+    },
+    cardTitle: {
+        fontWeight: 'bold',
+        fontSize: '28px',
+        textAlign: 'left',
+    },
+    cardBody: {
+        fontSize: '17px',
+        textAlign: 'left',
+    },
+    padding: {
+        paddingLeft: '70px',
+    },
 }));
 
 function SmallDisplayCard() {
     const classes = useStyles();
 
     return (
-        <Card>
-            Card
+        <Card className={classes.smallDisplayCard}>
+            <Box className={classes.padding}>
+                <Typography className={classes.cardTitle} variant="body1" component="div">
+                    Card
+                </Typography>
+                <Typography className={classes.cardBody} variant="body1" component="div">
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+                </Typography>
+            </Box>
         </Card>
     );
 }

--- a/client/src/SmallDisplayCard.tsx
+++ b/client/src/SmallDisplayCard.tsx
@@ -5,16 +5,29 @@ import { Card, Box } from '@material-ui/core';
 
 import type { Theme } from '@material-ui/core/styles';
 
+const circleSize = 76;
+const width = 325;
+const height = 133;
+
 const useStyles = makeStyles((theme: Theme) => ({
     smallDisplayCard: {
+        // Should probably move the sizing out of the component, maybe pass it in
+        maxWidth: `${width}px`,
+        height: `${height}px`,
+        display: 'flex',
+        flexDirection: 'row',
+        alignItems: 'flex-start',
+        justifyContent: 'center',
+        backgroundColor: '#767676',
+        color: '#FFFFFF',
+    },
+    content: {
+        height: '100%',
+        paddingLeft: '50px',
         display: 'flex',
         flexDirection: 'column',
         alignItems: 'flex-start',
         justifyContent: 'center',
-        width: '325px',
-        height: '133px',
-        backgroundColor: '#767676',
-        color: '#FFFFFF',
     },
     cardTitle: {
         fontWeight: 'bold',
@@ -22,11 +35,25 @@ const useStyles = makeStyles((theme: Theme) => ({
         textAlign: 'left',
     },
     cardBody: {
-        fontSize: '17px',
+        fontSize: '15px',
         textAlign: 'left',
     },
-    padding: {
-        paddingLeft: '70px',
+    circleWrapper: {
+        width: '1px',
+        height: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'center',
+        alignItems: 'flex-start',
+        flexWrap: 'nowrap',
+    },
+    circle: {
+        backgroundColor: '#FFFFFF',
+        borderRadius: '50%',
+        width: `${circleSize}px`,
+        height: `${circleSize}px`,
+        left: `-${circleSize/2}px`,
+        position: 'relative',
     },
 }));
 
@@ -35,7 +62,10 @@ function SmallDisplayCard() {
 
     return (
         <Card className={classes.smallDisplayCard}>
-            <Box className={classes.padding}>
+            <Box className={classes.circleWrapper}>
+                <Box className={classes.circle}></Box>
+            </Box>
+            <Box className={classes.content}>
                 <Typography className={classes.cardTitle} variant="body1" component="div">
                     Card
                 </Typography>

--- a/client/src/TrustAndSafety.tsx
+++ b/client/src/TrustAndSafety.tsx
@@ -41,12 +41,13 @@ const useStyles = makeStyles((theme: Theme) => ({
     // rows need break point
     buttonRow: {
         width: '100%',
-        maxWidth: '800px',
+        // maxWidth: '800px',
         display: 'flex',
         flexDirection: 'row',
-        justifyContent: 'space-between',
+        justifyContent: 'space-around',
         paddingTop: '50px',
         paddingBottom: '50px',
+        maxWidth: '1200px',
     },
     bigSpacer: {
         height: '400px',
@@ -84,6 +85,9 @@ const useStyles = makeStyles((theme: Theme) => ({
     trustText: {
         fontSize: '1.4rem',
         textAlign: 'left',
+    },
+    smallDisplayCard: {
+        margin: '10px',
     },
 }));
 

--- a/client/src/TrustAndSafety.tsx
+++ b/client/src/TrustAndSafety.tsx
@@ -10,8 +10,6 @@ import type { Theme } from '@material-ui/core/styles';
 const loremIpsum = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Facilisis placerat et, at vel tristique. Ac, gravida in quam gravida. Vel pretium nunc cursus donec enim. Sapien facilisis mauris justo, augue pharetra. Dignissim euismod fermentum sit gravida ut.";
 
 const useStyles = makeStyles((theme: Theme) => ({
-    root: {
-    },
     header: {
         fontWeight: 'bold',
         marginBottom: 15
@@ -47,9 +45,11 @@ const useStyles = makeStyles((theme: Theme) => ({
         display: 'flex',
         flexDirection: 'row',
         justifyContent: 'space-around',
-        paddingTop: '50px',
-        paddingBottom: '50px',
+        margin: '50px 10px 50px 10px',
         maxWidth: '1200px',
+        '& > div': {
+            margin: '10px',
+        }
     },
     bigSpacer: {
         height: '400px',
@@ -87,9 +87,6 @@ const useStyles = makeStyles((theme: Theme) => ({
     trustText: {
         fontSize: '1.4rem',
         textAlign: 'left',
-    },
-    smallDisplayCard: {
-        margin: '10px',
     },
 }));
 

--- a/client/src/TrustAndSafety.tsx
+++ b/client/src/TrustAndSafety.tsx
@@ -54,34 +54,20 @@ const useStyles = makeStyles((theme: Theme) => ({
             fill: '#F8F8F8',
         },
     },
-    whyCreatedContainer: {
-    },
-    trustContainer: {
-    },
-    // rows need break point for small screens
-    buttonRow: {
-        width: '100%',
-        // maxWidth: '800px',
-        display: 'flex',
-        flexDirection: 'row',
-        justifyContent: 'space-around',
-        margin: '50px 10px 50px 10px',
-        maxWidth: '1200px',
-        '& > div': {
-            margin: '10px',
-        }
-    },
-    bigSpacer: {
-        height: '400px',
-    },
-    trustRow: {
+    row: {
         width: '100%',
         display: 'flex',
         flexDirection: 'row',
         justifyContent: 'space-around',
+        flexWrap: 'wrap',
         paddingTop: '50px',
         paddingBottom: '50px',
         maxWidth: '1200px',
+    },
+    buttonRow: {
+        '& > div': {
+            margin: '10px',
+        }
     },
     trustListItem: {
         display: 'flex',
@@ -89,8 +75,10 @@ const useStyles = makeStyles((theme: Theme) => ({
         alignItems: 'center',
         justifyContent: 'flex-start',
         maxWidth: '400px',
-        marginLeft: '15px',
-        marginRight: '15px',
+        '& > div': {
+            marginLeft: '10px',
+            marginRight: '10px',
+        }
     },
     imagePlaceholder: {
         width: '168px',
@@ -102,11 +90,15 @@ const useStyles = makeStyles((theme: Theme) => ({
         fontWeight: 'bold',
         fontSize: '1.4rem',
         marginBottom: '7px',
-        marginTop: '65px',
+        marginTop: '50px',
     },
     trustText: {
         fontSize: '1.4rem',
         textAlign: 'left',
+        paddingBottom: '50px',
+    },
+    bigSpacer: {
+        height: '400px',
     },
 }));
 
@@ -131,7 +123,7 @@ function TrustAndSafety() {
                     <Typography className={classes.headerText} variant="body1" component="div">
                         {loremIpsum}
                     </Typography>
-                    <Box className={classes.buttonRow}>
+                    <Box className={`${classes.row} ${classes.buttonRow}`}>
                         <SmallDisplayCard
                             headerText="Trust"
                             bodyText={loremIpsum.slice(0,56)}
@@ -152,7 +144,7 @@ function TrustAndSafety() {
                     </svg>
                 </Box>
             </Box>
-            <Box className={`${classes.whyCreatedContainer} ${classes.mainPageSection}`}>
+            <Box className={`${classes.mainPageSection}`}>
                 <Typography className={classes.header} variant="h3" component="h3" align="center">
                     Why was NEH created?
                 </Typography>
@@ -162,11 +154,11 @@ function TrustAndSafety() {
                 </Typography>
             </Box>
             <Box className={classes.bigSpacer}></Box>
-            <Box className={`${classes.trustContainer} ${classes.mainPageSection}`}>
+            <Box className={`${classes.mainPageSection}`}>
                 <Typography className={classes.header} variant="h3" component="h3" align="center">
                     Trust
                 </Typography>
-                <Box className={classes.trustRow}>
+                <Box className={`${classes.row}`}>
                     <Box className={classes.trustListItem}>
                         <Box className={classes.imagePlaceholder}></Box>
                         <Typography className={classes.trustTitle} variant="body1" component="div">

--- a/client/src/TrustAndSafety.tsx
+++ b/client/src/TrustAndSafety.tsx
@@ -1,7 +1,164 @@
 import * as React from 'react';
+import Typography from '@material-ui/core/Typography';
+import { makeStyles } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
+
+import SmallDisplayCard from './SmallDisplayCard';
+
+import type { Theme } from '@material-ui/core/styles';
+
+const useStyles = makeStyles((theme: Theme) => ({
+    root: {
+    },
+    header: {
+        fontWeight: 'bold',
+        marginBottom: 15
+    },
+    headerText: {
+        width: '90%',
+        maxWidth: '1100px',
+        fontSize: '1.3rem',
+    },
+    mainPageSection: {
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        paddingTop: '50px',
+        paddingBottom: '50px',
+        fontSize: '1.4rem',
+    },
+    titleBox: {
+        height: 500,
+    },
+    guidelinesContainer: {
+        backgroundColor: '#EBEBEB',
+    },
+    whyCreatedContainer: {
+    },
+    trustContainer: {
+    },
+    // rows need break point
+    buttonRow: {
+        width: '100%',
+        maxWidth: '800px',
+        display: 'flex',
+        flexDirection: 'row',
+        justifyContent: 'space-between',
+        paddingTop: '50px',
+        paddingBottom: '50px',
+    },
+    bigSpacer: {
+        height: '400px',
+    },
+    trustRow: {
+        width: '100%',
+        display: 'flex',
+        flexDirection: 'row',
+        justifyContent: 'space-around',
+        paddingTop: '50px',
+        paddingBottom: '50px',
+        maxWidth: '1200px',
+    },
+    trustListItem: {
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'flex-start',
+        maxWidth: '400px',
+        marginLeft: '15px',
+        marginRight: '15px',
+    },
+    imagePlaceholder: {
+        width: '168px',
+        height: '168px',
+        border: '1px solid black',
+        backgroundColor: '#C4C4C4',
+    },
+    trustTitle: {
+        fontWeight: 'bold',
+        fontSize: '1.4rem',
+        marginBottom: '7px',
+        marginTop: '65px',
+    },
+    trustText: {
+        fontSize: '1.4rem',
+        textAlign: 'left',
+    },
+}));
 
 function TrustAndSafety() {
-    return <div>TrustAndSafety</div>;
+    const classes = useStyles();
+
+    return (
+        <>
+            <Box className={`${classes.titleBox} ${classes.mainPageSection}`}>
+                <Typography className={classes.header} variant="h3" component="h3" align="center">
+                    Trust, Safety, & Privacy
+                </Typography>
+                <Typography className={classes.headerText} variant="body1" component="div">
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+                </Typography>
+            </Box>
+            <Box className={`${classes.guidelinesContainer} ${classes.mainPageSection}`}>
+                <Typography className={classes.header} variant="h3" component="h3" align="center">
+                    Our Community Guidelines
+                </Typography>
+                <Typography className={classes.headerText} variant="body1" component="div">
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+                </Typography>
+                <Box className={classes.buttonRow}>
+                    <SmallDisplayCard />
+                    <SmallDisplayCard />
+                    <SmallDisplayCard />
+                </Box>
+            </Box>
+            <Box className={`${classes.whyCreatedContainer} ${classes.mainPageSection}`}>
+                <Typography className={classes.header} variant="h3" component="h3" align="center">
+                    Why was NEH created?
+                </Typography>
+                <Typography className={classes.headerText} variant="body1" component="div">
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Facilisis placerat et, at vel tristique. Ac, gravida in quam gravida. Vel pretium nunc cursus donec enim. Sapien facilisis mauris justo, augue pharetra. Dignissim euismod fermentum sit gravida ut.
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Facilisis placerat et, at vel tristique. Ac, gravida in quam gravida. Vel pretium nunc cursus donec enim. Sapien facilisis mauris justo, augue pharetra. Dignissim euismod fermentum sit gravida ut.
+                </Typography>
+            </Box>
+            <Box className={classes.bigSpacer}></Box>
+            <Box className={`${classes.trustContainer} ${classes.mainPageSection}`}>
+                <Typography className={classes.header} variant="h3" component="h3" align="center">
+                    Trust
+                </Typography>
+                <Box className={classes.trustRow}>
+                    <Box className={classes.trustListItem}>
+                        <Box className={classes.imagePlaceholder}></Box>
+                        <Typography className={classes.trustTitle} variant="body1" component="div">
+                            No Scams
+                        </Typography>
+                        <Typography className={classes.trustText} variant="body1" component="div">
+                            Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+                        </Typography>
+                    </Box>
+                    <Box className={classes.trustListItem}>
+                        <Box className={classes.imagePlaceholder}></Box>
+                        <Typography className={classes.trustTitle} variant="body1" component="div">
+                            Always be honest
+                        </Typography>
+                        <Typography className={classes.trustText} variant="body1" component="div">
+                            Lorem ipsum dolor sit amet, consectetur adipiscing elit. 
+                        </Typography>
+                    </Box>
+                    <Box className={classes.trustListItem}>
+                        <Box className={classes.imagePlaceholder}></Box>
+                        <Typography className={classes.trustTitle} variant="body1" component="div">
+                            No misrepresentation
+                        </Typography>
+                        <Typography className={classes.trustText} variant="body1" component="div">
+                            Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+                        </Typography>
+                    </Box>
+                </Box>
+            </Box>
+        </>
+    );
 }
 
 export default TrustAndSafety;

--- a/client/src/TrustAndSafety.tsx
+++ b/client/src/TrustAndSafety.tsx
@@ -7,6 +7,8 @@ import SmallDisplayCard from './SmallDisplayCard';
 
 import type { Theme } from '@material-ui/core/styles';
 
+const loremIpsum = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Facilisis placerat et, at vel tristique. Ac, gravida in quam gravida. Vel pretium nunc cursus donec enim. Sapien facilisis mauris justo, augue pharetra. Dignissim euismod fermentum sit gravida ut.";
+
 const useStyles = makeStyles((theme: Theme) => ({
     root: {
     },
@@ -38,7 +40,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     },
     trustContainer: {
     },
-    // rows need break point
+    // rows need break point for small screens
     buttonRow: {
         width: '100%',
         // maxWidth: '800px',
@@ -101,7 +103,7 @@ function TrustAndSafety() {
                     Trust, Safety, & Privacy
                 </Typography>
                 <Typography className={classes.headerText} variant="body1" component="div">
-                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+                    {loremIpsum}
                 </Typography>
             </Box>
             <Box className={`${classes.guidelinesContainer} ${classes.mainPageSection}`}>
@@ -109,7 +111,7 @@ function TrustAndSafety() {
                     Our Community Guidelines
                 </Typography>
                 <Typography className={classes.headerText} variant="body1" component="div">
-                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+                    {loremIpsum}
                 </Typography>
                 <Box className={classes.buttonRow}>
                     <SmallDisplayCard />
@@ -122,8 +124,8 @@ function TrustAndSafety() {
                     Why was NEH created?
                 </Typography>
                 <Typography className={classes.headerText} variant="body1" component="div">
-                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Facilisis placerat et, at vel tristique. Ac, gravida in quam gravida. Vel pretium nunc cursus donec enim. Sapien facilisis mauris justo, augue pharetra. Dignissim euismod fermentum sit gravida ut.
-                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Facilisis placerat et, at vel tristique. Ac, gravida in quam gravida. Vel pretium nunc cursus donec enim. Sapien facilisis mauris justo, augue pharetra. Dignissim euismod fermentum sit gravida ut.
+                    {loremIpsum}
+                    {loremIpsum}
                 </Typography>
             </Box>
             <Box className={classes.bigSpacer}></Box>
@@ -138,7 +140,7 @@ function TrustAndSafety() {
                             No Scams
                         </Typography>
                         <Typography className={classes.trustText} variant="body1" component="div">
-                            Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+                            {loremIpsum.slice(0,50)}.
                         </Typography>
                     </Box>
                     <Box className={classes.trustListItem}>
@@ -147,7 +149,7 @@ function TrustAndSafety() {
                             Always be honest
                         </Typography>
                         <Typography className={classes.trustText} variant="body1" component="div">
-                            Lorem ipsum dolor sit amet, consectetur adipiscing elit. 
+                            {loremIpsum.slice(0,50)}.
                         </Typography>
                     </Box>
                     <Box className={classes.trustListItem}>
@@ -156,7 +158,7 @@ function TrustAndSafety() {
                             No misrepresentation
                         </Typography>
                         <Typography className={classes.trustText} variant="body1" component="div">
-                            Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+                            {loremIpsum.slice(0,50)}.
                         </Typography>
                     </Box>
                 </Box>

--- a/client/src/TrustAndSafety.tsx
+++ b/client/src/TrustAndSafety.tsx
@@ -33,6 +33,26 @@ const useStyles = makeStyles((theme: Theme) => ({
     },
     guidelinesContainer: {
         backgroundColor: '#EBEBEB',
+        overflow: 'hidden',
+    },
+    guidelinesContent: {
+        position: 'relative',
+        zIndex: 10,
+    },
+    guidelinesBGWrapper: {
+        position: 'relative',
+        width: '100%',
+        height: '0',
+        zIndex: 2,
+        '& svg': {
+            position: 'absolute',
+            top: '-300px',
+            bottom: '0',
+            left: '0',
+            width: '100%',
+            height: '300px',
+            fill: '#F8F8F8',
+        },
     },
     whyCreatedContainer: {
     },
@@ -103,26 +123,33 @@ function TrustAndSafety() {
                     {loremIpsum}
                 </Typography>
             </Box>
-            <Box className={`${classes.guidelinesContainer} ${classes.mainPageSection}`}>
-                <Typography className={classes.header} variant="h3" component="h3" align="center">
-                    Our Community Guidelines
-                </Typography>
-                <Typography className={classes.headerText} variant="body1" component="div">
-                    {loremIpsum}
-                </Typography>
-                <Box className={classes.buttonRow}>
-                    <SmallDisplayCard
-                        headerText="Trust"
-                        bodyText={loremIpsum.slice(0,56)}
-                    />
-                    <SmallDisplayCard
-                        headerText="Safety"
-                        bodyText={loremIpsum.slice(0,56)}
-                    />
-                    <SmallDisplayCard
-                        headerText="Privacy"
-                        bodyText={loremIpsum.slice(0,56)}
-                    />
+            <Box className={`${classes.guidelinesContainer}`}>
+                <Box className={`${classes.guidelinesContent} ${classes.mainPageSection}`}>
+                    <Typography className={classes.header} variant="h3" component="h3" align="center">
+                        Our Community Guidelines
+                    </Typography>
+                    <Typography className={classes.headerText} variant="body1" component="div">
+                        {loremIpsum}
+                    </Typography>
+                    <Box className={classes.buttonRow}>
+                        <SmallDisplayCard
+                            headerText="Trust"
+                            bodyText={loremIpsum.slice(0,56)}
+                        />
+                        <SmallDisplayCard
+                            headerText="Safety"
+                            bodyText={loremIpsum.slice(0,56)}
+                        />
+                        <SmallDisplayCard
+                            headerText="Privacy"
+                            bodyText={loremIpsum.slice(0,56)}
+                        />
+                    </Box>
+                </Box>
+                <Box className={classes.guidelinesBGWrapper}>
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" preserveAspectRatio="none">
+                        <polygon points="0,100 100,0 100,100"/>
+                    </svg>
                 </Box>
             </Box>
             <Box className={`${classes.whyCreatedContainer} ${classes.mainPageSection}`}>

--- a/client/src/TrustAndSafety.tsx
+++ b/client/src/TrustAndSafety.tsx
@@ -114,9 +114,18 @@ function TrustAndSafety() {
                     {loremIpsum}
                 </Typography>
                 <Box className={classes.buttonRow}>
-                    <SmallDisplayCard />
-                    <SmallDisplayCard />
-                    <SmallDisplayCard />
+                    <SmallDisplayCard
+                        headerText="Trust"
+                        bodyText={loremIpsum.slice(0,56)}
+                    />
+                    <SmallDisplayCard
+                        headerText="Safety"
+                        bodyText={loremIpsum.slice(0,56)}
+                    />
+                    <SmallDisplayCard
+                        headerText="Privacy"
+                        bodyText={loremIpsum.slice(0,56)}
+                    />
                 </Box>
             </Box>
             <Box className={`${classes.whyCreatedContainer} ${classes.mainPageSection}`}>


### PR DESCRIPTION
The page is all set up to look like the prototype on Figma. I wasn't sure if there is a specific way to format the font for the project, if the site's stylesheet should do that automatically.

I created SmallDisplayCard to use on this page and others. Text to display is passed in via props.

Code and stylesheet could probably be simplified further, I'm still getting the hang of using React and JSS as opposed to a central stylesheet for a project.


![FireShot Capture 278 - Nonprofit Exchange Hub - localhost](https://user-images.githubusercontent.com/49460529/125210671-4c0b7a80-e26f-11eb-817d-99e4c179d21f.png)
