### PR TITLE
SignupCitizen and Login component updates

### DIFF
--- a/client/src/EmailInput.tsx
+++ b/client/src/EmailInput.tsx
@@ -1,0 +1,66 @@
+import FormControl from '@material-ui/core/FormControl';
+import Input from '@material-ui/core/Input';
+import MailOutlineIcon from '@material-ui/icons/MailOutline';
+import InputAdornment from '@material-ui/core/InputAdornment';
+import type { Theme } from '@material-ui/core/styles';
+import { makeStyles } from '@material-ui/core/styles';
+import * as React from 'react';
+
+const useStyles = makeStyles((theme: Theme) => {
+    return {
+        input: {
+            height: 62,
+            border: '1px solid #C4C4C4',
+            boxSizing: 'border-box',
+            padding: theme.spacing(1),
+            paddingLeft: theme.spacing(2),
+            paddingRight: theme.spacing(2),
+            fontSize: 18,
+            marginBottom: 20,
+        },
+        label: {
+            color: '#000000',
+            textAlign: 'left',
+        },
+    };
+});
+interface Props {
+    onChange: React.ChangeEventHandler<HTMLInputElement>;
+    value: string;
+    placeholder: string;
+    startAdornment?: boolean;
+}
+
+function EmailInput({ onChange, value, placeholder, startAdornment = false }: Props) {
+    const classes = useStyles();
+
+    return (
+        <FormControl fullWidth>
+            <label className={classes.label} htmlFor="email">
+                Email Address
+            </label>
+            <Input
+                className={classes.input}
+                type="email"
+                id="email"
+                name="email"
+                autoComplete="email"
+                placeholder={placeholder}
+                fullWidth
+                value={value}
+                onChange={onChange}
+                disableUnderline
+                required
+                startAdornment={
+                    startAdornment && (
+                        <InputAdornment position="start">
+                            <MailOutlineIcon />
+                        </InputAdornment>
+                    )
+                }
+            />
+        </FormControl>
+    );
+}
+
+export default EmailInput;

--- a/client/src/FacebookAuthBtn.tsx
+++ b/client/src/FacebookAuthBtn.tsx
@@ -22,7 +22,7 @@ function FacebookAuthBtn({ children }: FacebookAuthBtnProps) {
     const classes = useStyles();
 
     const facebookSignIn = (evt: React.MouseEvent) => {
-        console.debug('facebookSignIn - evt.currentTarget:', evt.currentTarget);
+        // Handle facebook sign up/in
     };
 
     return (

--- a/client/src/FacebookAuthBtn.tsx
+++ b/client/src/FacebookAuthBtn.tsx
@@ -1,0 +1,40 @@
+import * as React from 'react';
+import Button from '@material-ui/core/Button';
+import FacebookIcon from '@material-ui/icons/Facebook';
+import { makeStyles } from '@material-ui/core/styles';
+import type { Theme } from '@material-ui/core/styles';
+
+const useStyles = makeStyles((theme: Theme) => {
+    return {
+        button: {
+            borderRadius: 0,
+            height: 62,
+            textTransform: 'none',
+        },
+    };
+});
+
+interface FacebookAuthBtnProps {
+    children: string;
+}
+
+function FacebookAuthBtn({ children }: FacebookAuthBtnProps) {
+    const classes = useStyles();
+
+    const facebookSignIn = (evt: React.MouseEvent) => {
+        console.debug('facebookSignIn - evt.currentTarget:', evt.currentTarget);
+    };
+
+    return (
+        <Button
+            className={classes.button}
+            startIcon={<FacebookIcon />}
+            onClick={facebookSignIn}
+            style={{ backgroundColor: '#1877F2', color: 'white' }}
+        >
+            {children}
+        </Button>
+    );
+}
+
+export default FacebookAuthBtn;

--- a/client/src/GoogleAuthBtn.tsx
+++ b/client/src/GoogleAuthBtn.tsx
@@ -1,0 +1,33 @@
+import * as React from 'react';
+import Button from '@material-ui/core/Button';
+import { makeStyles } from '@material-ui/core/styles';
+import type { Theme } from '@material-ui/core/styles';
+
+const useStyles = makeStyles((theme: Theme) => {
+    return {
+        button: {
+            borderRadius: 0,
+            height: 62,
+            textTransform: 'none',
+        },
+    };
+});
+
+interface GoogleAuthBtnProps {
+    children: string;
+}
+
+function GoogleAuthBtn({children}:GoogleAuthBtnProps) {
+    const classes = useStyles();
+    const googleSignIn = (evt: React.MouseEvent) => {
+        console.debug('googleSignIn - evt.currentTarget:', evt.currentTarget);
+    };
+
+    return (
+        <Button className={classes.button} variant="outlined" onClick={googleSignIn}>
+            {children}
+        </Button>
+    );
+}
+
+export default GoogleAuthBtn;

--- a/client/src/GoogleAuthBtn.tsx
+++ b/client/src/GoogleAuthBtn.tsx
@@ -20,7 +20,7 @@ interface GoogleAuthBtnProps {
 function GoogleAuthBtn({children}:GoogleAuthBtnProps) {
     const classes = useStyles();
     const googleSignIn = (evt: React.MouseEvent) => {
-        console.debug('googleSignIn - evt.currentTarget:', evt.currentTarget);
+        // Handle googleSignIn
     };
 
     return (

--- a/client/src/Login.tsx
+++ b/client/src/Login.tsx
@@ -65,7 +65,6 @@ function Login() {
 
     const handleSubmit = async (evt: React.FormEvent) => {
         evt.preventDefault();
-        console.debug('handleSubmit - formData: ', formData);
         try {
             const res = await fetch('http://localhost:3001/api/auth/login', {
                 method: 'POST',
@@ -76,9 +75,8 @@ function Login() {
             });
             const accessToken = await res.json()
             history.push('/')
-            console.log('handleSubmit', accessToken)
         } catch (err) {
-            console.debug('handleSubmit - err', err);
+            // Handle error
         }
     };
 

--- a/client/src/Login.tsx
+++ b/client/src/Login.tsx
@@ -1,17 +1,17 @@
-import * as React from 'react';
-import Paper from '@material-ui/core/Paper';
-import Typography from '@material-ui/core/Typography';
-import Grid from '@material-ui/core/Grid';
 import Button from '@material-ui/core/Button';
-import FormControl from '@material-ui/core/FormControl';
-import Input from '@material-ui/core/Input';
-import FacebookIcon from '@material-ui/icons/Facebook';
-import Visibility from '@material-ui/icons/Visibility';
-import VisibilityOff from '@material-ui/icons/VisibilityOff';
-import InputAdornment from '@material-ui/core/InputAdornment';
-import IconButton from '@material-ui/core/IconButton';
-import { makeStyles, Theme } from '@material-ui/core/styles';
+import Grid from '@material-ui/core/Grid';
+import Paper from '@material-ui/core/Paper';
+import type { Theme } from '@material-ui/core/styles';
+import { makeStyles } from '@material-ui/core/styles';
+import Typography from '@material-ui/core/Typography';
+import * as React from 'react';
+import { useHistory } from 'react-router-dom';
+import EmailInput from './EmailInput';
+import FacebookAuthBtn from './FacebookAuthBtn';
+import GoogleAuthBtn from './GoogleAuthBtn';
+import PasswordInput from './PasswordInput';
 import StyledLink from './StyledLink';
+import TextDivider from './TextDivider';
 
 const useStyles = makeStyles((theme: Theme) => {
     const xPadding = 12;
@@ -29,82 +29,38 @@ const useStyles = makeStyles((theme: Theme) => {
             paddingBottom: theme.spacing(yPadding),
             paddingLeft: theme.spacing(xPadding),
             paddingRight: theme.spacing(xPadding),
-            margin: 'auto'
+            margin: 'auto',
         },
         header: { fontWeight: 'bold', marginBottom: 68 },
         button: {
             borderRadius: 0,
             height: 62,
-            textTransform: 'none'
+            textTransform: 'none',
         },
-        link: {
-            color: 'black'
-        },
-        input: {
-            height: 62,
-            border: '1px solid #C4C4C4',
-            boxSizing: 'border-box',
-            padding: theme.spacing(1),
-            paddingLeft: theme.spacing(2),
-            paddingRight: theme.spacing(2),
-            fontSize: 18,
-            marginBottom: 20
-        },
-        label: {
-            color: '#000000',
-            textAlign: 'left'
-        },
-        separator: {
-            display: 'flex',
-            alignItems: 'center',
-            textAlign: 'center',
-            '&::before': {
-                content: '""',
-                flex: 1,
-                borderBottom: '1px solid #C4C4C4'
-            },
-            '&::after': {
-                content: '""',
-                flex: 1,
-                borderBottom: '1px solid #C4C4C4'
-            },
-            '&:not(:empty)::before': {
-                marginRight: '.5em'
-            },
-            '&:not(:empty)::after': {
-                marginLeft: '.5em'
-            }
-        }
     };
 });
 
+interface UserLoginData {
+    email: string;
+    password: string;
+}
+
+const initialFormData: UserLoginData = {
+    email: '',
+    password: '',
+};
 function Login() {
     const classes = useStyles();
-
-    interface UserLoginData {
-        email: string;
-        password: string;
-    }
-
-    const initialFormData: UserLoginData = {
-        email: '',
-        password: ''
-    };
+    const history = useHistory();
 
     const [ formData, setFormData ] = React.useState(initialFormData);
-    const [ showPassword, setShowPassword ] = React.useState(false);
 
     const handleChange = (evt: React.ChangeEvent<HTMLInputElement>): void => {
         const { name, value }: { name: string; value: string } = evt.target;
         setFormData((fData) => ({
             ...fData,
-            [name]: value
+            [name]: value,
         }));
-    };
-
-    // Toggle password visibility
-    const handleClickShowPassword = () => {
-        setShowPassword(!showPassword);
     };
 
     const handleSubmit = async (evt: React.FormEvent) => {
@@ -114,22 +70,16 @@ function Login() {
             const res = await fetch('http://localhost:3001/api/auth/login', {
                 method: 'POST',
                 headers: {
-                    'Content-Type': 'application/json'
+                    'Content-Type': 'application/json',
                 },
-                body: JSON.stringify({ username: 'TestFirst', password: 'TestPass' })
+                body: JSON.stringify(formData),
             });
-            console.debug('handleSubmit - res', res);
-        } catch (error) {
-            console.debug('handleSubmit - err', error);
+            const accessToken = await res.json()
+            history.push('/')
+            console.log('handleSubmit', accessToken)
+        } catch (err) {
+            console.debug('handleSubmit - err', err);
         }
-    };
-
-    const googleSignIn = (evt: React.MouseEvent) => {
-        console.debug('googleSignIn - evt.currentTarget:', evt.currentTarget);
-    };
-
-    const facebookSignIn = (evt: React.MouseEvent) => {
-        console.debug('facebookSignIn - evt.currentTarget:', evt.currentTarget);
     };
 
     return (
@@ -142,73 +92,20 @@ function Login() {
                         </Typography>
                     </Grid>
                     <Grid item xs={12} container justify="space-between">
-                        <Button className={classes.button} variant="outlined" onClick={googleSignIn}>
-                            Sign In with Google
-                        </Button>
-                        <Button
-                            className={classes.button}
-                            startIcon={<FacebookIcon />}
-                            onClick={facebookSignIn}
-                            style={{ backgroundColor: '#1877F2', color: 'white' }}
-                        >
-                            Sign In with Facebook
-                        </Button>
+                        <GoogleAuthBtn>Sign In with Google</GoogleAuthBtn>
+                        <FacebookAuthBtn>Sign In with Facebook</FacebookAuthBtn>
                     </Grid>
                     <Grid item xs={12}>
-                        <div className={classes.separator}>
-                            <Typography variant="h6" component="span" align="center" style={{ color: '#C4C4C4' }}>
-                                or
-                            </Typography>
-                        </div>
+                        <TextDivider>or</TextDivider>
                     </Grid>
                     <Grid container item xs={12}>
                         <form onSubmit={handleSubmit} style={{ width: '100%' }}>
-                            <FormControl fullWidth>
-                                <label className={classes.label} htmlFor="email">
-                                    Email Address
-                                </label>
-
-                                <Input
-                                    className={classes.input}
-                                    type="text"
-                                    id="email"
-                                    name="email"
-                                    autoComplete="email"
-                                    placeholder="jane@nonprofit.com"
-                                    fullWidth
-                                    value={formData.email}
-                                    onChange={handleChange}
-                                    disableUnderline
-                                />
-                            </FormControl>
-                            <FormControl fullWidth>
-                                <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 16 }}>
-                                    <label className={classes.label} htmlFor="password">
-                                        Password
-                                    </label>
-                                    <StyledLink to="/forgot_password">Forgot Password?</StyledLink>
-                                </div>
-                                <Input
-                                    className={classes.input}
-                                    id="password"
-                                    name="password"
-                                    type={showPassword ? 'text' : 'password'}
-                                    value={formData.password}
-                                    onChange={handleChange}
-                                    disableUnderline
-                                    endAdornment={
-                                        <InputAdornment position="end">
-                                            <IconButton
-                                                aria-label="toggle password visibility"
-                                                onClick={handleClickShowPassword}
-                                                edge="end"
-                                            >
-                                                {showPassword ? <Visibility /> : <VisibilityOff />}
-                                            </IconButton>
-                                        </InputAdornment>
-                                    }
-                                />
-                            </FormControl>
+                            <EmailInput
+                                value={formData.email}
+                                placeholder="jane@nonprofit.com"
+                                onChange={handleChange}
+                            />
+                            <PasswordInput value={formData.password} onChange={handleChange} showForgot={true} />
                             <Button
                                 className={classes.button}
                                 style={{ backgroundColor: '#C4C4C4', color: 'white' }}

--- a/client/src/PasswordInput.tsx
+++ b/client/src/PasswordInput.tsx
@@ -1,0 +1,89 @@
+import FormControl from '@material-ui/core/FormControl';
+import IconButton from '@material-ui/core/IconButton';
+import Input from '@material-ui/core/Input';
+import InputAdornment from '@material-ui/core/InputAdornment';
+import type { Theme } from '@material-ui/core/styles';
+import { makeStyles } from '@material-ui/core/styles';
+import LockIcon from '@material-ui/icons/Lock';
+import Visibility from '@material-ui/icons/Visibility';
+import VisibilityOff from '@material-ui/icons/VisibilityOff';
+import * as React from 'react';
+import StyledLink from './StyledLink';
+
+const useStyles = makeStyles((theme: Theme) => {
+    return {
+        input: {
+            height: 62,
+            border: '1px solid #C4C4C4',
+            boxSizing: 'border-box',
+            padding: theme.spacing(1),
+            paddingLeft: theme.spacing(2),
+            paddingRight: theme.spacing(2),
+            fontSize: 18,
+            marginBottom: 20,
+        },
+        label: {
+            color: '#000000',
+            textAlign: 'left',
+        },
+    };
+});
+
+interface Props {
+    onChange: React.ChangeEventHandler<HTMLInputElement>;
+    value: string;
+    startAdornment?: boolean;
+    showForgot?: boolean;
+}
+
+function PasswordInput({ onChange, value, startAdornment = false, showForgot=false }: Props) {
+    const classes = useStyles();
+
+    const [ showPassword, setShowPassword ] = React.useState(false);
+
+    // Toggle password visibility
+    const handleClickShowPassword = () => {
+        setShowPassword(!showPassword);
+    };
+
+    return (
+        <FormControl fullWidth>
+            <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 16 }}>
+                <label className={classes.label} htmlFor="password">
+                    Password
+                </label>
+                {showForgot && <StyledLink to="/forgot_password">Forgot Password?</StyledLink>}
+            </div>
+            <Input
+                className={classes.input}
+                id="password"
+                name="password"
+                type={showPassword ? 'text' : 'password'}
+                value={value}
+                onChange={onChange}
+                disableUnderline
+                required
+                startAdornment={
+                    startAdornment && (
+                        <InputAdornment position="start">
+                            <LockIcon />
+                        </InputAdornment>
+                    )
+                }
+                endAdornment={
+                    <InputAdornment position="end">
+                        <IconButton
+                            aria-label="toggle password visibility"
+                            onClick={handleClickShowPassword}
+                            edge="end"
+                        >
+                            {showPassword ? <Visibility /> : <VisibilityOff />}
+                        </IconButton>
+                    </InputAdornment>
+                }
+            />
+        </FormControl>
+    );
+}
+
+export default PasswordInput;

--- a/client/src/PasswordInput.tsx
+++ b/client/src/PasswordInput.tsx
@@ -61,6 +61,7 @@ function PasswordInput({ onChange, value, startAdornment = false, showForgot=fal
                 type={showPassword ? 'text' : 'password'}
                 value={value}
                 onChange={onChange}
+                autoComplete={showForgot ? 'current-password' : 'new-password'}
                 disableUnderline
                 required
                 startAdornment={

--- a/client/src/SignupCitizen.tsx
+++ b/client/src/SignupCitizen.tsx
@@ -79,12 +79,10 @@ function SignupCitizen() {
             ...fData,
             [name]: name ==='accept_terms' ? checked : value,
         }));
-        console.log(formData);
     };
 
     const handleSubmit = async (evt: React.FormEvent) => {
         evt.preventDefault();
-        console.debug('handleSubmit - formData: ', formData);
         try {
             const res = await fetch('http://localhost:3001/api/users', {
                 method: 'POST',
@@ -93,10 +91,9 @@ function SignupCitizen() {
                 },
                 body: JSON.stringify(formData),
             });
-            console.debug('handleSubmit - res', res);
             history.push('/');
         } catch (err) {
-            console.debug('handleSubmit - err', err);
+            // Handle err
         }
     };
 

--- a/client/src/SignupCitizen.tsx
+++ b/client/src/SignupCitizen.tsx
@@ -128,7 +128,7 @@ function SignupCitizen() {
                                         type="text"
                                         id="first_name"
                                         name="first_name"
-                                        autoComplete="email"
+                                        autoComplete="given-name"
                                         placeholder="Jane"
                                         fullWidth
                                         value={formData.first_name}
@@ -149,7 +149,7 @@ function SignupCitizen() {
                                         type="text"
                                         id="last_name"
                                         name="last_name"
-                                        autoComplete="email"
+                                        autoComplete="family-name"
                                         placeholder="Individual"
                                         fullWidth
                                         value={formData.last_name}

--- a/client/src/SignupCitizen.tsx
+++ b/client/src/SignupCitizen.tsx
@@ -1,47 +1,206 @@
+import FormControl from '@material-ui/core/FormControl';
+import Grid from '@material-ui/core/Grid';
+import Input from '@material-ui/core/Input';
+import type { Theme } from '@material-ui/core/styles';
+import { makeStyles } from '@material-ui/core/styles';
+import Typography from '@material-ui/core/Typography';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
+import Checkbox from '@material-ui/core/Checkbox';
+import Button from '@material-ui/core/Button';
 import * as React from 'react';
+import { useHistory } from 'react-router-dom';
+import { placeholderImg } from './assets/temp';
+import EmailInput from './EmailInput';
+import FacebookAuthBtn from './FacebookAuthBtn';
+import GoogleAuthBtn from './GoogleAuthBtn';
+import PasswordInput from './PasswordInput';
+import StyledLink from './StyledLink';
+import TextDivider from './TextDivider';
+
+const useStyles = makeStyles((theme: Theme) => ({
+    sideImg: {
+        backgroundImage: `url("${placeholderImg}")`,
+        backgroundSize: 'cover',
+        backgroundPosition: 'center center',
+        backgroundRepeat: 'no-repeat',
+    },
+    signUpContainer: {
+        margin: theme.spacing(5),
+    },
+    button: {
+        borderRadius: 0,
+        height: 62,
+        textTransform: 'none',
+        backgroundColor: '#C4C4C4',
+        color: 'white',
+    },
+    header: { fontWeight: 'bold' },
+    input: {
+        height: 62,
+        border: '1px solid #C4C4C4',
+        boxSizing: 'border-box',
+        padding: theme.spacing(1),
+        paddingLeft: theme.spacing(2),
+        paddingRight: theme.spacing(2),
+        fontSize: 18,
+        marginBottom: 20,
+    },
+    label: {
+        color: '#000000',
+        textAlign: 'left',
+    },
+}));
+
+interface UserSignupData {
+    first_name: string;
+    last_name: string;
+    email: string;
+    password: string;
+    accept_terms: boolean;
+}
+
+const initialFormData: UserSignupData = {
+    first_name: '',
+    last_name: '',
+    email: '',
+    password: '',
+    accept_terms: false,
+};
 
 function SignupCitizen() {
+    const classes = useStyles();
+    const history = useHistory();
+
+    const [ formData, setFormData ] = React.useState(initialFormData);
+
+    const handleChange = (evt: React.ChangeEvent<HTMLInputElement>): void => {
+        const { name, value, checked }: { name: string; value: string; checked: boolean } = evt.target;
+        setFormData((fData) => ({
+            ...fData,
+            [name]: name ==='accept_terms' ? checked : value,
+        }));
+        console.log(formData);
+    };
+
+    const handleSubmit = async (evt: React.FormEvent) => {
+        evt.preventDefault();
+        console.debug('handleSubmit - formData: ', formData);
+        try {
+            const res = await fetch('http://localhost:3001/api/users', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify(formData),
+            });
+            console.debug('handleSubmit - res', res);
+            history.push('/');
+        } catch (err) {
+            console.debug('handleSubmit - err', err);
+        }
+    };
+
     return (
-        <React.Fragment>
-            <div>Let's Get Started.</div>
-            <div>
-                Already have an account? <a>Log In</a>
-            </div>
-            <div>
-                <button>Sign Up With Google</button>
-                <button>Sign Up With Facebook</button>
-            </div>
-            <div>or</div>
-            <div>
-                <span>First Name</span>
-                <span>Last Name</span>
-            </div>
-            <div>
-                <input type="text" name="first_name" />
-                <input type="text" name="last_name" />
-            </div>
-            <div>
-                <span>Email Address</span>
-            </div>
-            <div>
-                <input type="text" name="email" />
-            </div>
-            <div>
-                <span>Password (6 or more characters)</span>
-            </div>
-            <div>
-                <input type="text" name="password" />
-            </div>
-            <div>
-                <input type="checkbox" name="accept_terms" id="accept_terms" />
-                <label htmlFor="accept_terms">
-                    Accept the <a>Terms and Agreements</a>
-                </label>
-            </div>
-            <div>
-                <button>Sign Up</button>
-            </div>
-        </React.Fragment>
+        <div className="SignupCitizen">
+            <Grid container>
+                <Grid className={classes.sideImg} item xs={5} />
+                <Grid container className={classes.signUpContainer} item direction="column" xs={6}>
+                    <Typography className={classes.header} variant="h4" component="h1" align="left" gutterBottom>
+                        Let's get started.
+                    </Typography>
+                    <Typography component="p" align="left" gutterBottom>
+                        Already have an account? <StyledLink to="/login">Log In</StyledLink>
+                    </Typography>
+                    <Grid container item justify="space-between">
+                        <GoogleAuthBtn>Sign Up with Google</GoogleAuthBtn>
+                        <FacebookAuthBtn>Sign Up With Facebook</FacebookAuthBtn>
+                    </Grid>
+                    <TextDivider>or</TextDivider>
+                    <form onSubmit={handleSubmit}>
+                        <Grid container item xs={12} justify="space-between">
+                            <Grid item xs={5}>
+                                <FormControl fullWidth>
+                                    <label className={classes.label} htmlFor="first_name">
+                                        First Name
+                                    </label>
+                                    <Input
+                                        className={classes.input}
+                                        type="text"
+                                        id="first_name"
+                                        name="first_name"
+                                        autoComplete="email"
+                                        placeholder="Jane"
+                                        fullWidth
+                                        value={formData.first_name}
+                                        onChange={handleChange}
+                                        disableUnderline
+                                        required
+                                    />
+                                </FormControl>
+                            </Grid>
+                            <Grid item xs={2} />
+                            <Grid item xs={5}>
+                                <FormControl fullWidth>
+                                    <label className={classes.label} htmlFor="last_name">
+                                        Last Name
+                                    </label>
+                                    <Input
+                                        className={classes.input}
+                                        type="text"
+                                        id="last_name"
+                                        name="last_name"
+                                        autoComplete="email"
+                                        placeholder="Individual"
+                                        fullWidth
+                                        value={formData.last_name}
+                                        onChange={handleChange}
+                                        disableUnderline
+                                        required
+                                    />
+                                </FormControl>
+                            </Grid>
+                        </Grid>
+                        <Grid container />
+                        <EmailInput
+                            value={formData.email}
+                            placeholder="jane@citizen.com"
+                            onChange={handleChange}
+                            startAdornment={true}
+                        />
+                        <PasswordInput value={formData.password} onChange={handleChange} startAdornment={true} />
+                        <FormControlLabel
+                            style={{ textAlign: 'left', display: 'block' }}
+                            control={
+                                <Checkbox
+                                    color="primary"
+                                    checked={formData.accept_terms}
+                                    onChange={handleChange}
+                                    name="accept_terms"
+                                    inputProps={{ 'aria-label': 'accept_terms_checkbox' }}
+                                />
+                            }
+                            label={
+                                <label>
+                                    Accept the{' '}
+                                    <StyledLink to="/terms_and_condtions" target="_blank">
+                                        Terms and Condtions
+                                    </StyledLink>
+                                </label>
+                            }
+                        />
+
+                        <Button
+                            className={classes.button}
+                            fullWidth
+                            type="submit"
+                            disabled={!formData.accept_terms}
+                        >
+                            Sign Up
+                        </Button>
+                    </form>
+                </Grid>
+            </Grid>
+        </div>
     );
 }
 

--- a/client/src/StyledLink.tsx
+++ b/client/src/StyledLink.tsx
@@ -17,16 +17,17 @@ const useStyles = makeStyles(() => {
     };
 });
 
-interface StyledLinkProps {
+interface Props {
     to: string;
+    target?: string;
     children: string;
 }
 
-function StyledLink({ to, children }: StyledLinkProps) {
+function StyledLink({ to,target, children }: Props) {
     const classes = useStyles();
 
     return (
-        <Link className={classes.link} component={RouterLink} to={to}>
+        <Link className={classes.link} component={RouterLink} to={to} target={target}>
             {children}
         </Link>
     );

--- a/client/src/TextDivider.tsx
+++ b/client/src/TextDivider.tsx
@@ -1,0 +1,52 @@
+import * as React from 'react';
+import Typography from '@material-ui/core/Typography';
+import { makeStyles } from '@material-ui/core/styles';
+import type { Theme } from '@material-ui/core/styles';
+
+const useStyles = makeStyles((theme: Theme) => {
+    return {
+        separator: {
+            display: 'flex',
+            alignItems: 'center',
+            textAlign: 'center',
+            '&::before': {
+                content: '""',
+                flex: 1,
+                borderBottom: '1px solid #C4C4C4',
+            },
+            '&::after': {
+                content: '""',
+                flex: 1,
+                borderBottom: '1px solid #C4C4C4',
+            },
+            '&:not(:empty)::before': {
+                marginRight: '.5em',
+            },
+            '&:not(:empty)::after': {
+                marginLeft: '.5em',
+            },
+        },
+        text:{
+            marginLeft: theme.spacing(1),
+            marginRight: theme.spacing(1)
+        }
+    };
+});
+
+interface TextDividerProps {
+    children: any;
+}
+
+function TextDivider({ children }: TextDividerProps) {
+    const classes = useStyles();
+
+    return (
+        <div className={classes.separator}>
+            <Typography className={classes.text} variant="h6" component="span" align="center" style={{ color: '#C4C4C4' }}>
+                {children}
+            </Typography>
+        </div>
+    );
+}
+
+export default TextDivider;

--- a/server/src/auth/auth.service.ts
+++ b/server/src/auth/auth.service.ts
@@ -30,7 +30,7 @@ export class AuthService {
     }
 
     async createJwt(user: any) {
-        const payload = { username: user.username, sub: user.userId };
+        const payload = {id:user.id, email:user.email};
         return {
             access_token: this.jwtService.sign(payload),
         };


### PR DESCRIPTION
Goodness do I wish I had made this PR before I went on vacation.

Overall the changes made were to create reusable subcomponents for the email and password inputs and google/facebook buttons of SignupCitizen and Login components.

Also improved some styles, primarily of SignupCitizen. Definitely still some work to be done, mostly with the sign up button, but I figure it can wait until we have more info from UI/UX crew.

SignupCitizen and Login connected to backend and will successfully create a user and return an access token with the correct inputs. We still need to set restrictions on the password input, currently just required, no min length or anything.

This PR does not handle errors in these cases. That will be for the next PR because it involves changing up response on the backend, and requires answering how we want to handle those situations of failed requests. In the past I've used Redux to handle pending request, and then respond appropriately based on a success or failure. Push to page on success, show errors on failure.

To Test:

- Create user from signup citizen creates a new user in the database and dev console returns 201.
- Trying to create a user without data won't allow submit.
- Logging in with successfully added user email and password returns an access_token, wrong inputs return a 401.

