### PR TITLE
added group header name class name, left margins, and font weight

### DIFF
--- a/client/src/FilterGroup.tsx
+++ b/client/src/FilterGroup.tsx
@@ -11,10 +11,12 @@ const useStyles = makeStyles((theme: Theme) => ({
         paddingTop: '20px',
     },
     filtersList: {
-        display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'center',
+        marginLeft: '20%'   
     },
+    groupHeader: {
+        fontWeight: 'bold',
+        marginLeft: '15%'        
+    }
 }));
 
 type Props = {
@@ -30,7 +32,7 @@ function FilterGroup(props: Props): JSX.Element {
 
     return (
         <div className={classes.wrapper}>
-            <Typography variant="h5" component="h5" color="textPrimary">
+            <Typography variant="h5" component="h5" color="textPrimary" className={classes.groupHeader}>
                 {header}
             </Typography>
             <div className={classes.filtersList}>

--- a/server/package.json
+++ b/server/package.json
@@ -12,7 +12,7 @@
         "start": "nest start",
         "start:dev": "nest start --watch",
         "start:debug": "nest start --debug --watch",
-        "start:dev:db": "docker-compose up",
+        "start:dev:db": "sudo docker-compose up",
         "start:prod": "node dist/main",
         "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
         "test": "jest",


### PR DESCRIPTION
Added a group header name class, left margins, and font weight to the search page: http://localhost:3000/assets?search=Toothbrush

1. go to http://localhost:3000/assets?search=Toothbrush
2. expect left side bar text to be aligned per attached image: 

![Screen Shot 2021-09-28 at 8 58 53 PM](https://user-images.githubusercontent.com/76884037/135185301-65e8b6c4-c97a-47d1-84b3-22d985a6c84a.png)
