### PR TITLE
import Repository and DeleteResult as types

### DIFF
--- a/server/src/assets/assets.service.ts
+++ b/server/src/assets/assets.service.ts
@@ -1,9 +1,10 @@
 import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import type { DeleteResult, Repository } from 'typeorm';
+
 import { Asset } from './entities/asset.entity';
-import { DeleteResult, Repository } from 'typeorm';
 import { CreateAssetDto } from './dto/create-asset.dto';
 import { UpdateAssetDto } from './dto/update-asset.dto';
-import { InjectRepository } from '@nestjs/typeorm';
 
 @Injectable()
 export class AssetsService {

--- a/server/src/messages/messages.service.ts
+++ b/server/src/messages/messages.service.ts
@@ -1,10 +1,11 @@
 import { Injectable } from '@nestjs/common';
-import { Message } from './entities/message.entity';
+import { InjectRepository } from '@nestjs/typeorm';
+import type { Repository, DeleteResult } from 'typeorm';
+
 import { User } from '../users/entities/user.entity';
-import { Repository, DeleteResult } from 'typeorm';
+import { Message } from './entities/message.entity';
 import { CreateMessageDto } from './dto/create-message.dto';
 import { UpdateMessageDto } from './dto/update-message.dto';
-import { InjectRepository } from '@nestjs/typeorm';
 
 @Injectable()
 export class MessagesService {

--- a/server/src/users/users.service.ts
+++ b/server/src/users/users.service.ts
@@ -1,10 +1,12 @@
 import { Catch, HttpException, HttpStatus, Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import type { Repository } from 'typeorm';
+
+import * as bcrypt from 'bcrypt';
+
 import { User } from './entities/user.entity';
-import { Repository } from 'typeorm';
 import { CreateUserDto } from './dto/create-user.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
-import { InjectRepository } from '@nestjs/typeorm';
-import * as bcrypt from 'bcrypt';
 
 @Injectable()
 // @Catch(QueryFailedError)


### PR DESCRIPTION
- Import `Repository` and `DeleteResult` from `typeorm` as types in asset, message and user services
- Reorder imports in relevant files so that framework and project-internal imports are grouped separately, with the former at the top

You can test messages in the same way as outlined in #46, which itself includes a couple of user requests. Assets can be tested in a similar way, using `title`, `description` and `quantity`, e.g.:
```
curl --request POST \
 --url http://localhost:3001/api/assets
 -H 'Content-Type: application/json'
 --data '{ 
   "title": "test 1",
   "description": "desc 1",
   "quantity": 1
   }'
```