### PR TITLE
update check/format commands to return to root

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -33,10 +33,10 @@ changes are includes. GIFs help immensely when explaining interactions and anima
 preReqs (to be checked by reviewer):
 
 - [ ] following command succeeds:
-`cd client && npm run checks && cd ../server && npm run checks`
+`cd client && npm run checks && cd ../server && npm run checks && cd ..`
 expect tests to pass
 - [ ] ensure all files have been formatted:
-`cd client && npm run format && cd ../server && npm run format`
+`cd client && npm run format && cd ../server && npm run format && cd ..`
 expect `git status` to show 0 files changed
 
 


### PR DESCRIPTION
Small edit to the check and format commands to return the user to the root `web-app` directory. Without this, you need to remember to run `cd ..` in between the two (chains of) commands