### PR TITLE
Danny b/add authguard to categories

### DIFF
--- a/server/src/categories/categories.controller.ts
+++ b/server/src/categories/categories.controller.ts
@@ -8,12 +8,14 @@ import {
   Delete,
   HttpException,
   HttpStatus,
+  UseGuards
 } from '@nestjs/common';
 import { CategoriesService } from './categories.service';
 import { CreateCategoryDto } from './dto/create-category';
 import { UpdateCategoryDto } from './dto/update-category';
 import { Category } from './entities/category.entity';
 import { DeleteResult } from 'typeorm';
+import { JwtAuthGuard } from 'src/auth/guards/jwt-auth.guard';
 
 // TODO ticket for adding auth guards https://github.com/Nonprofit-Exchange-Hub/web-app/issues/84
 
@@ -21,6 +23,7 @@ import { DeleteResult } from 'typeorm';
 export class CategoriesController {
   constructor(private readonly categoriesService: CategoriesService) {}
 
+  @UseGuards(JwtAuthGuard)
   @Post()
   async create(@Body() createCategoryDto: CreateCategoryDto): Promise<Category> {
     try {

--- a/server/src/categories/categories.controller.ts
+++ b/server/src/categories/categories.controller.ts
@@ -8,7 +8,7 @@ import {
   Delete,
   HttpException,
   HttpStatus,
-  UseGuards
+  UseGuards,
 } from '@nestjs/common';
 import { CategoriesService } from './categories.service';
 import { CreateCategoryDto } from './dto/create-category';

--- a/server/src/categories/categories.controller.ts
+++ b/server/src/categories/categories.controller.ts
@@ -56,6 +56,7 @@ export class CategoriesController {
     return foundCategory;
   }
 
+  @UseGuards(JwtAuthGuard)
   @Patch(':id')
   async update(
     @Param('id') id: string,
@@ -75,6 +76,7 @@ export class CategoriesController {
     }
   }
 
+  @UseGuards(JwtAuthGuard)
   @Delete(':id')
   async remove(@Param('id') id: string): Promise<DeleteResult> {
     const categoryToDelete = await this.categoriesService.remove(parseInt(id));

--- a/server/src/categories/categories.service.ts
+++ b/server/src/categories/categories.service.ts
@@ -4,6 +4,7 @@ import { UpdateCategoryDto } from './dto/update-category';
 import { InjectRepository } from '@nestjs/typeorm';
 import { DeleteResult, Repository } from 'typeorm';
 import { Category } from './entities/category.entity';
+import { JwtAuthGuard } from 'src/auth/guards/jwt-auth.guard';
 
 @Injectable()
 export class CategoriesService {


### PR DESCRIPTION
Added JwtAuthGuards to categories resource. I did not apply auth guards to the controller actions for searching categories. This ensures a user can still find categories but will need to be authorized to create, edit, or delete categories.

Here is a POST, PATCH, and DELETE call in Postman to show the unauthorized 401 code after sending the request:

![](https://user-images.githubusercontent.com/54184719/148660257-29888159-c13e-404b-aebd-1b430dce7580.png)

![category patch unauth](https://user-images.githubusercontent.com/54184719/148669892-2d7d3430-306c-43e4-a549-400772daa0d4.png)

![category delete unauth](https://user-images.githubusercontent.com/54184719/148669888-4b71462d-fd52-46c0-8483-83a182caf4f7.png)

GET all categories and GET by id are still accessible.

![categories get with auth](https://user-images.githubusercontent.com/54184719/148669935-795030c4-a225-4dcc-acbe-f1f54425231c.png)

![catergory by id](https://user-images.githubusercontent.com/54184719/148669907-3f8524b4-5b66-4406-8c39-d733325fbcb4.png)


