### PR TITLE
fix private route bug

### DIFF
--- a/client/src/components/Forms/NeedGoodsForm/NeedGoodsForm.tsx
+++ b/client/src/components/Forms/NeedGoodsForm/NeedGoodsForm.tsx
@@ -70,7 +70,7 @@ function NeedGoodsForm(): JSX.Element {
   const [formData, setFormData] = React.useState<ShareANeedData>(initialFormData);
   const [formInProgress, setFormInProgress] = React.useState<boolean>(false);
   const [categories, setCategories] = React.useState<Option[]>([]);
-  const [user] = React.useContext(UserContext);
+  const { user } = React.useContext(UserContext);
   const [urlError, setUrlError] = React.useState({ '0': '' });
 
   const history = useHistory();

--- a/client/src/components/Header.tsx
+++ b/client/src/components/Header.tsx
@@ -73,7 +73,7 @@ const useStyles = makeStyles((theme: Theme) => ({
 function Header() {
   const LOGOUT_URL = `${APP_API_BASE_URL}/auth/logout`;
   const classes = useStyles();
-  const [user, setUser] = React.useContext(UserContext);
+  const { user, setUser } = React.useContext(UserContext);
   const history = useHistory();
 
   const [navAnchorEl, setNavAnchorEl] = React.useState<null | HTMLElement>(null);

--- a/client/src/components/Users/Auth/SetNewPassword.tsx
+++ b/client/src/components/Users/Auth/SetNewPassword.tsx
@@ -48,7 +48,7 @@ function SetNewPassword() {
     setPassword(evt.target.value);
   };
 
-  const [user] = React.useContext(UserContext);
+  const { user } = React.useContext(UserContext);
 
   const handleSubmit = async (evt: React.FormEvent): Promise<void> => {
     evt.preventDefault();

--- a/client/src/providers/UserProvider.tsx
+++ b/client/src/providers/UserProvider.tsx
@@ -41,19 +41,17 @@ export function UserProvider(props: React.PropsWithChildren<{}>): JSX.Element {
   }
 
   async function setUserTimeout(
-    user: User | null,
+    currentUser: User | null,
     shouldFetch = false,
     shouldStartTimer = false,
   ): Promise<void> {
-    let newUser: User | null = user;
+    let newUser: User | null = currentUser;
     if (shouldFetch) {
-      setIsLoading(true);
       newUser = await fetchUser();
     }
 
     setUser(newUser);
-
-    if (isLoading) setIsLoading(false);
+    setIsLoading(false);
 
     if (shouldStartTimer && newUser) {
       setTimeout(() => {

--- a/client/src/routes/PrivateRouteWrapper/index.tsx
+++ b/client/src/routes/PrivateRouteWrapper/index.tsx
@@ -9,9 +9,12 @@ type Props = {
 };
 
 const PrivateRoute = ({ roles, children }: Props) => {
-  const [user] = useContext(UserContext);
+  const { user, isLoading } = useContext(UserContext);
   // use cookies
   // insert user.roles.includes(roles) check
+  if (isLoading) {
+    return <div>LOADING</div>;
+  }
   return user ? children : <Redirect to={routes.Login.path} />;
 };
 

--- a/client/src/views/Inbox.tsx
+++ b/client/src/views/Inbox.tsx
@@ -127,7 +127,7 @@ const fetchMessages = async (): Promise<Message[]> => {
 // maybe call it SearchBar and have an optional leftContent prop?
 function MessageInboxView(): JSX.Element {
   const classes = useStyles();
-  const [user] = React.useContext(UserContext);
+  const { user } = React.useContext(UserContext);
   const [transactions, setTransactions] = React.useState<Transaction[]>([]);
   const [selectedTransaction, setSelectedTransaction] = React.useState<Transaction | null>(null);
   const [messages, setMessages] = React.useState<Message[]>([]);

--- a/client/src/views/Login.tsx
+++ b/client/src/views/Login.tsx
@@ -65,7 +65,7 @@ function Login() {
   const history = useHistory();
   const [isLoading, setIsLoading] = React.useState<boolean>(false);
   const [error, setError] = React.useState<Error | null>(null);
-  const [, setUser] = React.useContext(UserContext);
+  const { setUser } = React.useContext(UserContext);
 
   const [formData, setFormData] = React.useState<UserLoginData>(initialFormData);
 


### PR DESCRIPTION
Fixed bug that was happening on reload in private routes. The page used to redirect to Login even if user was logged in, because redirecting was happening before user object was loaded. I added an 'isLoading' attribute to the UserContext to prevent this. UserContext now looks like {user, setUser, isLoading} instead of [user, setUser].