### PR TITLE
clean up search bar and share on home and search results pages

### DIFF
--- a/client/src/components/DonationsCarousel.tsx
+++ b/client/src/components/DonationsCarousel.tsx
@@ -29,7 +29,7 @@ export default function DonationsCarousel(props: DonationsCarouselProps) {
         cardWidth={250}
         showControls={true}
         label={props.label || ''}
-        viewMoreTo="/SearchResults?category=Offers"
+        viewMoreTo="/search-results?category=Offers"
       />
     </div>
   );

--- a/client/src/components/DonationsCarousel.tsx
+++ b/client/src/components/DonationsCarousel.tsx
@@ -29,6 +29,7 @@ export default function DonationsCarousel(props: DonationsCarouselProps) {
         cardWidth={250}
         showControls={true}
         label={props.label || ''}
+        viewMoreTo="/SearchResults?category=Offers"
       />
     </div>
   );

--- a/client/src/components/NeedsCarousel.tsx
+++ b/client/src/components/NeedsCarousel.tsx
@@ -30,7 +30,7 @@ export default function NeedsCarousel(props: NeedsCarouselProps) {
         cardWidth={250}
         showControls={true}
         label={props.label || ''}
-        viewMoreTo="/SearchResults?category=Needs"
+        viewMoreTo="/search-results?category=Needs"
       />
     </div>
   );

--- a/client/src/components/NeedsCarousel.tsx
+++ b/client/src/components/NeedsCarousel.tsx
@@ -30,6 +30,7 @@ export default function NeedsCarousel(props: NeedsCarouselProps) {
         cardWidth={250}
         showControls={true}
         label={props.label || ''}
+        viewMoreTo="/SearchResults?category=Needs"
       />
     </div>
   );

--- a/client/src/components/ResponsiveCarousel.tsx
+++ b/client/src/components/ResponsiveCarousel.tsx
@@ -1,9 +1,11 @@
 import * as React from 'react';
+import { NavLink } from 'react-router-dom';
 import Typography from '@mui/material/Typography';
 import ExpandCircleDownOutlinedIcon from '@mui/icons-material/ExpandCircleDownOutlined';
 import Button from '@mui/material/Button';
 import Paper from '@mui/material/Paper';
 import makeStyles from '@mui/styles/makeStyles';
+
 import type { Theme } from '@mui/material/styles';
 
 const useStyles = makeStyles((theme: Theme) => ({
@@ -36,6 +38,7 @@ type ResponsiveCarouselProps = {
   renderCard: Function;
   cardWidth: number;
   showControls: boolean;
+  viewMoreTo: string;
 };
 
 function ResponsiveCarousel(props: ResponsiveCarouselProps) {
@@ -48,7 +51,7 @@ function ResponsiveCarousel(props: ResponsiveCarouselProps) {
   const wrapperRef = React.useRef<HTMLDivElement>(null);
   const cardMargin = 10;
   const MaxItems = 5;
-  const { label, cardWidth } = props;
+  const { label, cardWidth, viewMoreTo } = props;
 
   const updateItemsPerRow = () => {
     let itemsThatFit = itemsPerRow;
@@ -129,19 +132,20 @@ function ResponsiveCarousel(props: ResponsiveCarouselProps) {
           </Paper>
         </div>
         <div>
-          <Button
-            href="#"
-            sx={{
-              padding: '0.4rem 1rem 0.4rem 1rem',
-              border: '1px solid #323232',
-              borderRadius: '8px',
-              color: '#323232',
-              fontWeight: '900',
-              fontSize: '1rem',
-            }}
-          >
-            View More
-          </Button>
+          <NavLink to={viewMoreTo} style={{ textDecoration: 'none' }}>
+            <Button
+              sx={{
+                padding: '0.4rem 1rem 0.4rem 1rem',
+                border: '1px solid #323232',
+                borderRadius: '8px',
+                color: '#323232',
+                fontWeight: '900',
+                fontSize: '1rem',
+              }}
+            >
+              View More
+            </Button>
+          </NavLink>
           {props.showControls ? ForwardAndBack : null}
         </div>
       </div>

--- a/client/src/components/Search.tsx
+++ b/client/src/components/Search.tsx
@@ -40,7 +40,7 @@ function Search() {
   const [searchText, setSearchText] = React.useState<string>((querySearchText as string) || '');
 
   const handleSearch = () => {
-    history.push(`/SearchResults?search=${searchText}&category=${searchCategory}`);
+    history.push(`/search-results?search=${searchText}&category=${searchCategory}`);
   };
 
   return (

--- a/client/src/components/Search.tsx
+++ b/client/src/components/Search.tsx
@@ -1,146 +1,129 @@
 import * as React from 'react';
-import makeStyles from '@mui/styles/makeStyles';
-import Select from '@mui/material/Select';
-import MenuItem from '@mui/material/MenuItem';
-import { SelectChangeEvent } from '@mui/material';
-import TextField from '@mui/material/TextField';
-import Tooltip from '@mui/material/Tooltip';
-import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import { useHistory } from 'react-router-dom';
+import makeStyles from '@mui/styles/makeStyles';
+import MenuItem from '@mui/material/MenuItem';
+import Paper from '@mui/material/Paper';
+import Box from '@mui/material/Box';
+import FormControl from '@mui/material/FormControl';
+import Select, { SelectChangeEvent } from '@mui/material/Select';
+import TextField from '@mui/material/TextField';
+import SearchIcon from '@mui/icons-material/Search';
+import Tooltip from '@mui/material/Tooltip';
 
 import type { Theme } from '@mui/material/styles';
 
 const useStyles = makeStyles((theme: Theme) => ({
   searchBar: {
-    fontFamily: 'DM Sans',
+    gridArea: 'searchBar',
+    boxShadow: 'none',
+    margin: '50px auto',
+    width: '70%',
+  },
+  searchInput: {
     display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
     width: '100%',
-    borderRadius: '10px',
-    boxShadow: '0px 2px 4px 2px rgba(0, 0, 0, 0.25)',
-  },
-  select: {
-    background: theme.palette.background.default,
-    borderRadius: '10px',
-    flexBasis: '30%',
-    position: 'relative',
-    zIndex: 10,
-    borderBottom: 'none',
-    paddingInline: '20px',
-    [`&:before`]: {
-      border: 'none !important',
-    },
-    [`& svg`]: {
-      right: '26px',
-    },
-  },
-  textField: {
-    background: theme.palette.background.default,
-    borderRadius: '10px',
-    flexBasis: '70%',
-    color: 'red',
-    // height: '48px',
-    boxSizing: 'border-box',
-    border: '1px solid red',
-    [`& label`]: {
-      marginTop: '-8px',
-      marginLeft: '20px',
-    },
-    [`& div`]: {
-      marginTop: '0px !important',
-      [`&:before`]: {
-        borderBottom: 'none !important',
-      },
-      [`& input`]: {
-        height: '48px',
-        paddingLeft: '20px',
-      },
-    },
+    height: '70px',
   },
 }));
 
-function getTextFieldLabel(selectValue: string, searchText: string): string {
-  if (searchText) {
-    return '';
-  }
-
-  switch (selectValue) {
-    case 'All':
-      return 'Search all categories';
-    case 'Nonprofits':
-      return 'Search Nonprofits';
-    case 'Needs':
-      return 'Search Needs';
-    case 'Offers':
-      return 'Search Offers';
-    case 'Volunteer':
-      return 'Search Volunteer Openings';
-    default:
-      return 'Search all categories';
-  }
-}
-
 function Search() {
   const classes = useStyles();
-  const [selectedSearchCategory, setSelectedSearchCategory] = React.useState<string>('Needs');
-  const [searchText, setSearchText] = React.useState<string>('');
-
   const history = useHistory();
 
-  const handleDropdownChange = (event: SelectChangeEvent<string>) => {
-    setSelectedSearchCategory(event.target.value as string);
+  const searchParams = new URLSearchParams(history.location.search);
+  const querySearchText = searchParams.get('search');
+  const querySearchCategory = searchParams.get('category');
+
+  const [searchCategory, setSearchCategory] = React.useState<string>(
+    (querySearchCategory as string) || 'Needs',
+  );
+  const [searchText, setSearchText] = React.useState<string>((querySearchText as string) || '');
+
+  const handleSearch = () => {
+    history.push(`/SearchResults?search=${searchText}&category=${searchCategory}`);
   };
 
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'Enter') {
-      history.push(`/SearchResults?search=${searchText}&category=${selectedSearchCategory}`);
-    }
-  };
-
-  const textFieldLabel = getTextFieldLabel(selectedSearchCategory, searchText);
   return (
     <div className={classes.searchBar}>
-      <Select
-        className={classes.select}
-        IconComponent={KeyboardArrowDownIcon}
-        onChange={handleDropdownChange}
-        renderValue={(value: string) => (value ? `Search ${value}` : 'Search All')}
-        value={selectedSearchCategory}
-        variant="standard"
-      >
-        <MenuItem value="All">Search All</MenuItem>
-        <MenuItem value="Nonprofits">Search Nonprofits</MenuItem>
-        <MenuItem value="Needs">Search Needs</MenuItem>
-        <MenuItem value="Offers">Search Offers</MenuItem>
-        <MenuItem value="Volunteer">Volunteer Openings</MenuItem>
-      </Select>
-      <Tooltip
-        placement="top-end"
-        componentsProps={{
-          tooltip: {
-            sx: {
-              color: 'rgba(0, 0, 0, 0.87)',
-              fontSize: 13,
-              bgcolor: 'common.white',
-              '& .MuiTooltip-arrow': {
-                color: 'common.white',
-              },
-            },
-          },
+      <Box
+        sx={{
+          display: 'flex',
+          border: '1px solid rgba(110, 110, 110, .22)',
+          borderRadius: '10px',
+          overflow: 'hidden',
+          height: '50px',
+          alignItems: 'center',
         }}
-        title="Press 'Enter' to Begin Search"
       >
-        <TextField
-          className={classes.textField}
-          InputLabelProps={{ shrink: false }}
-          label={textFieldLabel}
-          onChange={(e: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) =>
-            setSearchText(e.target.value)
-          }
-          onKeyDown={handleKeyDown}
-          value={searchText}
-          variant="outlined"
-        />
-      </Tooltip>
+        <FormControl
+          sx={{
+            minWidth: '200px',
+            display: 'flex',
+            justifyContent: 'center',
+          }}
+        >
+          <Select
+            labelId="demo-simple-select-label"
+            id="demo-simple-select"
+            value={searchCategory}
+            sx={{
+              '& #demo-simple-select': {
+                fontSize: '20px',
+                paddingLeft: '20%',
+                backgroundColor: 'white',
+              },
+            }}
+            onChange={(e: SelectChangeEvent) => {
+              setSearchCategory(e.target.value);
+            }}
+            inputProps={{ sx: { border: 'none' } }}
+          >
+            <MenuItem value="All">All</MenuItem>
+            <MenuItem value="Nonprofits">Nonprofits</MenuItem>
+            <MenuItem value="Needs">Needs</MenuItem>
+            <MenuItem value="Offers">Offers</MenuItem>
+            <MenuItem value="Volunteer">Volunteer</MenuItem>
+          </Select>
+        </FormControl>
+
+        <Paper className={classes.searchInput}>
+          <Tooltip
+            placement="top-end"
+            componentsProps={{
+              tooltip: {
+                sx: {
+                  color: 'rgba(0, 0, 0, 0.87)',
+                  fontSize: '18px',
+                  bgcolor: 'common.white',
+                  '& .MuiTooltip-arrow': {
+                    color: 'common.white',
+                  },
+                },
+              },
+            }}
+            title="Press 'Enter' key or Click the Icon to Search"
+          >
+            <TextField
+              sx={{
+                '& .MuiOutlinedInput-notchedOutline': {
+                  border: 'none',
+                },
+              }}
+              placeholder="Search"
+              inputProps={{ 'aria-label': 'ex. diapers', style: { fontSize: '18px' } }}
+              type="text"
+              value={searchText}
+              onKeyDown={(e) => e.key === 'Enter' && handleSearch()}
+              onChange={(e: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => {
+                setSearchText(e.target.value);
+              }}
+            />
+          </Tooltip>
+          <SearchIcon fontSize="large" onClick={handleSearch} sx={{ paddingRight: '10px' }} />
+        </Paper>
+      </Box>
     </div>
   );
 }

--- a/client/src/components/Search.tsx
+++ b/client/src/components/Search.tsx
@@ -35,9 +35,9 @@ function Search() {
   const querySearchCategory = searchParams.get('category');
 
   const [searchCategory, setSearchCategory] = React.useState<string>(
-    (querySearchCategory as string) || 'Needs',
+    String(querySearchCategory ?? 'Needs'),
   );
-  const [searchText, setSearchText] = React.useState<string>((querySearchText as string) || '');
+  const [searchText, setSearchText] = React.useState<string>(String(querySearchText ?? ''));
 
   const handleSearch = () => {
     history.push(`/search-results?search=${searchText}&category=${searchCategory}`);
@@ -90,7 +90,11 @@ function Search() {
             setSearchText(e.target.value);
           }}
         />
-        <IconButton onClick={handleSearch} sx={{ paddingRight: '10px', marginLeft: 'auto' }}>
+        <IconButton
+          onClick={handleSearch}
+          sx={{ paddingRight: '10px', marginLeft: 'auto' }}
+          disabled={!searchText}
+        >
           <SearchIcon fontSize="large" />
         </IconButton>
       </Paper>

--- a/client/src/components/Search.tsx
+++ b/client/src/components/Search.tsx
@@ -3,12 +3,10 @@ import { useHistory } from 'react-router-dom';
 import makeStyles from '@mui/styles/makeStyles';
 import MenuItem from '@mui/material/MenuItem';
 import Paper from '@mui/material/Paper';
-import Box from '@mui/material/Box';
-import FormControl from '@mui/material/FormControl';
 import Select, { SelectChangeEvent } from '@mui/material/Select';
 import TextField from '@mui/material/TextField';
 import SearchIcon from '@mui/icons-material/Search';
-import Tooltip from '@mui/material/Tooltip';
+import IconButton from '@mui/material/IconButton';
 
 import type { Theme } from '@mui/material/styles';
 
@@ -47,83 +45,55 @@ function Search() {
 
   return (
     <div className={classes.searchBar}>
-      <Box
+      <Paper
+        component="form"
         sx={{
-          display: 'flex',
-          border: '1px solid rgba(110, 110, 110, .22)',
           borderRadius: '10px',
-          overflow: 'hidden',
-          height: '50px',
+          display: 'flex',
           alignItems: 'center',
+          justifyContent: 'flex-start',
+          width: '100%',
+          boxShadow: 'none',
+          border: '1px solid rgba(110, 110, 110, .22)',
+          height: '50px',
         }}
       >
-        <FormControl
+        <Select
+          value={searchCategory}
           sx={{
-            minWidth: '200px',
-            display: 'flex',
-            justifyContent: 'center',
+            fontSize: '20px',
+            '.MuiOutlinedInput-notchedOutline': { border: 0 },
+            height: '50px',
+          }}
+          onChange={(e: SelectChangeEvent) => {
+            setSearchCategory(e.target.value);
           }}
         >
-          <Select
-            labelId="demo-simple-select-label"
-            id="demo-simple-select"
-            value={searchCategory}
-            sx={{
-              '& #demo-simple-select': {
-                fontSize: '20px',
-                paddingLeft: '20%',
-                backgroundColor: 'white',
-              },
-            }}
-            onChange={(e: SelectChangeEvent) => {
-              setSearchCategory(e.target.value);
-            }}
-            inputProps={{ sx: { border: 'none' } }}
-          >
-            <MenuItem value="All">All</MenuItem>
-            <MenuItem value="Nonprofits">Nonprofits</MenuItem>
-            <MenuItem value="Needs">Needs</MenuItem>
-            <MenuItem value="Offers">Offers</MenuItem>
-            <MenuItem value="Volunteer">Volunteer</MenuItem>
-          </Select>
-        </FormControl>
-
-        <Paper className={classes.searchInput}>
-          <Tooltip
-            placement="top-end"
-            componentsProps={{
-              tooltip: {
-                sx: {
-                  color: 'rgba(0, 0, 0, 0.87)',
-                  fontSize: '18px',
-                  bgcolor: 'common.white',
-                  '& .MuiTooltip-arrow': {
-                    color: 'common.white',
-                  },
-                },
-              },
-            }}
-            title="Press 'Enter' key or Click the Icon to Search"
-          >
-            <TextField
-              sx={{
-                '& .MuiOutlinedInput-notchedOutline': {
-                  border: 'none',
-                },
-              }}
-              placeholder="Search"
-              inputProps={{ 'aria-label': 'ex. diapers', style: { fontSize: '18px' } }}
-              type="text"
-              value={searchText}
-              onKeyDown={(e) => e.key === 'Enter' && handleSearch()}
-              onChange={(e: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => {
-                setSearchText(e.target.value);
-              }}
-            />
-          </Tooltip>
-          <SearchIcon fontSize="large" onClick={handleSearch} sx={{ paddingRight: '10px' }} />
-        </Paper>
-      </Box>
+          <MenuItem value="All">All</MenuItem>
+          <MenuItem value="Nonprofits">Nonprofits</MenuItem>
+          <MenuItem value="Needs">Needs</MenuItem>
+          <MenuItem value="Offers">Offers</MenuItem>
+          <MenuItem value="Volunteer">Volunteer</MenuItem>
+        </Select>
+        <TextField
+          sx={{
+            '& .MuiOutlinedInput-notchedOutline': {
+              border: 'none',
+            },
+          }}
+          placeholder="Search"
+          inputProps={{ 'aria-label': 'ex. diapers', style: { fontSize: '18px' } }}
+          type="text"
+          value={searchText}
+          onKeyDown={(e) => e.key === 'Enter' && handleSearch()}
+          onChange={(e: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => {
+            setSearchText(e.target.value);
+          }}
+        />
+        <IconButton onClick={handleSearch} sx={{ paddingRight: '10px', marginLeft: 'auto' }}>
+          <SearchIcon fontSize="large" />
+        </IconButton>
+      </Paper>
     </div>
   );
 }

--- a/client/src/components/SearchCategoryCard.tsx
+++ b/client/src/components/SearchCategoryCard.tsx
@@ -15,9 +15,6 @@ const useStyles = makeStyles({
     gap: '0.8em',
     padding: '30px 0 30px 20px',
   },
-  root: {
-    // backgroundColor: 'white',
-  },
   icon: {
     borderRadius: '50%',
     width: 18,
@@ -54,7 +51,6 @@ function StyledRadio(props: RadioProps) {
 
   return (
     <Radio
-      className={classes.root}
       disableRipple
       color="default"
       checkedIcon={<span className={clsx(classes.icon, classes.checkedIcon)} />}
@@ -77,6 +73,7 @@ export default function SearchCategoryCard() {
       >
         {categories.map((t) => (
           <FormControlLabel
+            key={t}
             value={t}
             control={<StyledRadio color="secondary" size="medium" />}
             label={<span style={{ fontSize: '18px', color: 'white' }}>{t}</span>}

--- a/client/src/routes/routes.ts
+++ b/client/src/routes/routes.ts
@@ -125,7 +125,7 @@ const routes: RouteMap = {
   Assets: {
     component: SearchResults,
     roles: ['OWNER', 'ADMIN'],
-    path: '/SearchResults',
+    path: '/search-results',
   },
   Asset: {
     component: Asset,

--- a/client/src/views/Home.tsx
+++ b/client/src/views/Home.tsx
@@ -1,36 +1,19 @@
-import makeStyles from '@mui/styles/makeStyles';
-
 import Search from '../components/Search';
 import BannerSection from '../components/BannerSection';
 import NeedsCarousel from '../components/NeedsCarousel';
 import DonationsCarousel from '../components/DonationsCarousel';
 import FAQs from '../components/FAQs';
 
-const useStyles = makeStyles(() => ({
-  needsAndOffers: {
-    padding: '10%',
-  },
-  makeAPostButton: {
-    marginLeft: '15px',
-  },
-  makeAPostLink: {
-    textDecoration: 'none',
-  },
-  searchContainer: {
-    maxWidth: '980px',
-    width: '70%',
-    margin: '30px auto',
-  },
-}));
+// searchContainer: {
+//   maxWidth: '980px',
+//   width: '70%',
+//   margin: '30px auto',
+// },
 
 function Home(): JSX.Element {
-  const classes = useStyles();
-
   return (
     <>
-      <div className={classes.searchContainer}>
-        <Search />
-      </div>
+      <Search />
       <BannerSection />
       <NeedsCarousel label={'Recent Needs From Nonprofits'} />
       <DonationsCarousel label={'Recent Offers From Users'} />

--- a/client/src/views/Home.tsx
+++ b/client/src/views/Home.tsx
@@ -4,12 +4,6 @@ import NeedsCarousel from '../components/NeedsCarousel';
 import DonationsCarousel from '../components/DonationsCarousel';
 import FAQs from '../components/FAQs';
 
-// searchContainer: {
-//   maxWidth: '980px',
-//   width: '70%',
-//   margin: '30px auto',
-// },
-
 function Home(): JSX.Element {
   return (
     <>

--- a/client/src/views/SearchResults.tsx
+++ b/client/src/views/SearchResults.tsx
@@ -18,14 +18,6 @@ import routes from '../routes/routes';
 import type { Asset, Organization } from '../types';
 
 const useStyles = makeStyles((theme: Theme) => ({
-  searchBody: {
-    gridArea: 'searchBody',
-    display: 'grid',
-    gridTemplateColumns: '300px 1fr',
-    gridTemplateRows: 'auto',
-    gridTemplateAreas: `'leftPanel rightPanel'`,
-    gap: '1em',
-  },
   searchResultsContainer: {
     display: 'grid',
     padding: '20px 10%',
@@ -41,6 +33,14 @@ const useStyles = makeStyles((theme: Theme) => ({
       backgroundColor: 'inherit',
       borderRadius: '10px',
     },
+  },
+  searchBody: {
+    gridArea: 'searchBody',
+    display: 'grid',
+    gridTemplateColumns: '300px 1fr',
+    gridTemplateRows: 'auto',
+    gridTemplateAreas: `'leftPanel rightPanel'`,
+    gap: '1em',
   },
   leftPanel: {
     gridArea: 'leftPanel',

--- a/client/src/views/SearchResults.tsx
+++ b/client/src/views/SearchResults.tsx
@@ -2,14 +2,6 @@ import * as React from 'react';
 import { NavLink, useHistory } from 'react-router-dom';
 
 import makeStyles from '@mui/styles/makeStyles';
-import Paper from '@mui/material/Paper';
-import Box from '@mui/material/Box';
-import MenuItem from '@mui/material/MenuItem';
-import FormControl from '@mui/material/FormControl';
-import Select, { SelectChangeEvent } from '@mui/material/Select';
-import TextField from '@mui/material/TextField';
-import SearchIcon from '@mui/icons-material/Search';
-import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 
 import type { Theme } from '@mui/material/styles';
@@ -18,6 +10,7 @@ import AssetsList from './AssetsList';
 import OrgsList from './OrgsList';
 import FilterGroup from '../components/FilterGroup';
 import SearchCategoryCard from '../components/SearchCategoryCard';
+import Search from '../components/Search';
 import { filters1, filters2, filters3 } from '../assets/temp';
 import { APP_API_BASE_URL } from '../configs';
 import routes from '../routes/routes';
@@ -25,6 +18,14 @@ import routes from '../routes/routes';
 import type { Asset, Organization } from '../types';
 
 const useStyles = makeStyles((theme: Theme) => ({
+  searchBody: {
+    gridArea: 'searchBody',
+    display: 'grid',
+    gridTemplateColumns: '300px 1fr',
+    gridTemplateRows: 'auto',
+    gridTemplateAreas: `'leftPanel rightPanel'`,
+    gap: '1em',
+  },
   searchResultsContainer: {
     display: 'grid',
     padding: '20px 10%',
@@ -34,32 +35,12 @@ const useStyles = makeStyles((theme: Theme) => ({
     gap: '4em 0',
     backgroundColor: '#f7fbfd',
   },
-  searchBar: {
-    gridArea: 'searchBar',
-    boxShadow: 'none',
-    margin: '20px 100px',
-  },
   iconButton: {
     padding: 10,
     '&:hover': {
       backgroundColor: 'inherit',
       borderRadius: '10px',
     },
-  },
-  searchInput: {
-    display: 'flex',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    width: '100%',
-    height: '70px',
-  },
-  searchBody: {
-    gridArea: 'searchBody',
-    display: 'grid',
-    gridTemplateColumns: '300px 1fr',
-    gridTemplateRows: 'auto',
-    gridTemplateAreas: `'leftPanel rightPanel'`,
-    gap: '1em',
   },
   leftPanel: {
     gridArea: 'leftPanel',
@@ -74,7 +55,6 @@ const useStyles = makeStyles((theme: Theme) => ({
     fontWeight: 'bold',
     marginLeft: '15%',
   },
-  createBar: {},
   rightHeader: {
     display: 'flex',
     flexDirection: 'row',
@@ -98,12 +78,7 @@ function SearchResults(): JSX.Element {
   const querySearchText = searchParams.get('search');
   const querySearchCategory = searchParams.get('category');
 
-  const [searchCategory, setSearchCategory] = React.useState<string>(
-    (querySearchCategory as string) || '',
-  );
-  const [searchText, setSearchText] = React.useState<string>((querySearchText as string) || '');
   const [selectedFilters, setSelectedFilters] = React.useState<{ [key: string]: boolean }>({});
-
   const [offers, setOffers] = React.useState<Asset[]>([]);
   const [needs, setNeeds] = React.useState<Asset[]>([]);
   const [orgs, setOrgs] = React.useState<Organization[]>([]);
@@ -151,96 +126,13 @@ function SearchResults(): JSX.Element {
     });
   };
 
-  const handleSearch = () => {
-    history.push(`/SearchResults?search=${searchText}&category=${searchCategory}`);
-  };
-
   React.useEffect(() => {
     fetchSearchData();
   }, [querySearchText, querySearchCategory]);
 
-  console.log('reouts', routes);
   return (
     <div className={classes.searchResultsContainer}>
-      <div className={classes.searchBar}>
-        <Box
-          sx={{
-            display: 'flex',
-            borderRadius: '10px',
-            overflow: 'hidden',
-            boxShadow: '1px 1px 5px 1px rgba(0,0,0,0.2)',
-            height: '50px',
-            alignItems: 'center',
-          }}
-        >
-          <FormControl
-            sx={{
-              minWidth: '200px',
-              display: 'flex',
-              justifyContent: 'center',
-            }}
-          >
-            <Select
-              labelId="demo-simple-select-label"
-              id="demo-simple-select"
-              value={searchCategory}
-              label="Age"
-              sx={{
-                '& #demo-simple-select': {
-                  fontSize: '20px',
-                  paddingLeft: '20%',
-                  backgroundColor: 'white',
-                },
-              }}
-              onChange={(e: SelectChangeEvent) => {
-                setSearchCategory(e.target.value);
-              }}
-            >
-              <MenuItem value="All">All</MenuItem>
-              <MenuItem value="Nonprofits">Nonprofits</MenuItem>
-              <MenuItem value="Needs">Needs</MenuItem>
-              <MenuItem value="Offers">Offers</MenuItem>
-              <MenuItem value="Volunteer">Volunteer</MenuItem>
-            </Select>
-          </FormControl>
-
-          <Paper className={classes.searchInput}>
-            <Tooltip
-              placement="top-end"
-              componentsProps={{
-                tooltip: {
-                  sx: {
-                    color: 'rgba(0, 0, 0, 0.87)',
-                    fontSize: '18px',
-                    bgcolor: 'common.white',
-                    '& .MuiTooltip-arrow': {
-                      color: 'common.white',
-                    },
-                  },
-                },
-              }}
-              title="Press 'Enter' key or Click the Icon to Search"
-            >
-              <TextField
-                sx={{
-                  '& .MuiOutlinedInput-notchedOutline': {
-                    border: '0 none',
-                  },
-                }}
-                placeholder="Search"
-                inputProps={{ 'aria-label': 'ex. diapers', style: { fontSize: '18px' } }}
-                type="text"
-                value={searchText}
-                onKeyDown={(e) => e.key === 'Enter' && handleSearch()}
-                onChange={(e: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => {
-                  setSearchText(e.target.value);
-                }}
-              />
-            </Tooltip>
-            <SearchIcon fontSize="large" onClick={handleSearch} />
-          </Paper>
-        </Box>
-      </div>
+      <Search />
       <div className={classes.searchBody}>
         <div className={classes.leftPanel}>
           <SearchCategoryCard />


### PR DESCRIPTION
## Dev Summary

the home page search bar styling was broken and it wasn't using the same component as the search results page
the good search bar itself also needed some tweaks
removed the tooltip (inherently bad accessibility)
also fixed the 'view more' buttons on the homepage

## Test Plan

repro steps:

1. localhost:3000
2. use search bar a bunch
3. use search bar a bunch from /SearchResults page

expect it to work intuitively for you
